### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     install_requires=[
-    	'cryptograpy>=3.1'
+    	'cryptography>=3.1'
     	]
 )
 


### PR DESCRIPTION
Updated typo that doesn't allow for installing this package

With this pull request applied it will be possible to install this package using:
`python -m pip install https://github.com/jvanovost/dc09_spt/archive/refs/heads/master.zip`

Without this pull request it fails due to unknown/no-match library.